### PR TITLE
Remove two sources of reading material

### DIFF
--- a/Week2/README.md
+++ b/Week2/README.md
@@ -25,9 +25,9 @@ Only watch the below chapters:
 2. Core Programming Syntax 
 3. Variables and Data Types
 
-- Read this ~ http://speakingjs.com/es5/ch01.html read up to and including the *Strings* chapter (it’s okay if you don’t understand all of it yet, we will cover these concepts in class as well. Do make sure to write or document the questions you have so we can discuss them in class)
 
-- Read the entire JavaScript Introduction at MDN~ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Introduction
+
+
 
 - Helpful resource: http://jsbooks.revolunet.com/ (here you can find tons of free JavaScript books online)
 


### PR DESCRIPTION
Both resources are very far from beginner friendly and clearly suppose previous coding experiences. 
Example of a sentence used in these resources:

"javaScript contains a standard library of objects, such as Array, Date, and Math, and a core set of language elements such as operators, control structures, and statements. Core JavaScript can be extended for a variety of purposes by supplementing it with additional objects"

As the level of English of some of our students is limited, and many have no background in programming, I think these resources are mostly just having students read information that they are not yet ready to process, and mostly will leave them confused. There are much better resources (that we have written ourselves) that explain it much better, and that we don't link to in the reading material of this week. (I have created a seperate pull request for this.