### PR TITLE
replace another link that is too hard to read

### DIFF
--- a/Week3/README.md
+++ b/Week3/README.md
@@ -32,10 +32,10 @@ Please watch the following parts of the course, [Programming Foundations Fundame
 - [Array](http://javascript.info/array)
 - [Loops](http://javascript.info/while-for)
 - [Functions](http://javascript.info/function-basics)
-- [Another Functions article](http://eloquentjavascript.net/03_functions.html)
+- [Scope](https://github.com/HackYourFuture/fundamentals/blob/master/fundamentals/scope.md)
 - [Objects](http://javascript.info/object)
 - [Conditions](http://javascript.info/ifelse)
-- [Program structure](http://eloquentjavascript.net/02_program_structure.html)
+- [Expressions vs statements](https://www.youtube.com/watch?v=WVyCrI1cHi8)
 
 #### Git work flow
 - Check out this video of Daan to see how we use Git Workflow to hand in Homework (from now on): https://www.youtube.com/watch?v=-o0yomUVVpU&index=2&list=PLVYDhqbgYpYUGxRdtQdYVE5Q8h3bt6SIA


### PR DESCRIPTION
replaced 2 links ( from eloquent javaScript) that is too hard to read for beginners / non native english speakers. 
the first I replaced it with our internal Scope documentation, that currently wasn't part of the reading (and is talked about in Eloquent JS) 
the second I replaced with a clear video on expressions vs statements. I think in general it's good to be very specific about what each reading is exactly about, and what you should get understand out of it.